### PR TITLE
feat: add local matchmaking and post-game summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "lobby": "node server.js"
   },
   "dependencies": {
     "backgammon-engine": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "ws": "^8.15.0"
   },
   "devDependencies": {
     "vite": "^5.2.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,56 @@
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 8080 });
+const waiting = [];
+const rooms = new Map(); // roomId -> [ws1, ws2]
+
+wss.on('connection', (ws) => {
+  ws.on('message', (message) => {
+    let data;
+    try {
+      data = JSON.parse(message);
+    } catch {
+      return;
+    }
+    if (data.type === 'join-lobby') {
+      waiting.push(ws);
+      tryMatch();
+    } else if (data.type === 'join-room') {
+      ws.roomId = data.roomId;
+      if (!rooms.has(ws.roomId)) rooms.set(ws.roomId, []);
+      rooms.get(ws.roomId).push(ws);
+    } else if (data.type === 'chat' && ws.roomId) {
+      const peers = rooms.get(ws.roomId) || [];
+      peers.forEach((client) => {
+        if (client !== ws && client.readyState === ws.OPEN) {
+          client.send(JSON.stringify({ type: 'chat', text: data.text }));
+        }
+      });
+    }
+  });
+
+  ws.on('close', () => {
+    const idx = waiting.indexOf(ws);
+    if (idx >= 0) waiting.splice(idx, 1);
+    if (ws.roomId && rooms.has(ws.roomId)) {
+      const peers = rooms.get(ws.roomId);
+      rooms.set(ws.roomId, peers.filter((p) => p !== ws));
+    }
+  });
+});
+
+function tryMatch() {
+  if (waiting.length >= 2) {
+    const p1 = waiting.shift();
+    const p2 = waiting.shift();
+    const roomId = Math.random().toString(36).slice(2, 8);
+    [p1, p2].forEach((ws) => {
+      ws.roomId = roomId;
+      if (!rooms.has(roomId)) rooms.set(roomId, []);
+      rooms.get(roomId).push(ws);
+      ws.send(JSON.stringify({ type: 'match', roomId }));
+    });
+  }
+}
+
+console.log('WebSocket lobby server running on ws://localhost:8080');

--- a/src/components/GameControls.jsx
+++ b/src/components/GameControls.jsx
@@ -1,8 +1,9 @@
-export default function GameControls({ onRoll, onReset }) {
+export default function GameControls({ onRoll, onReset, onEnd }) {
   return (
     <div className="game-controls">
       <button onClick={onRoll}>Roll Dice</button>
       <button onClick={onReset}>New Game</button>
+      {onEnd && <button onClick={onEnd}>End Game</button>}
     </div>
   );
 }

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import Board from '../components/Board.jsx';
 import Dice from '../components/Dice.jsx';
 import GameControls from '../components/GameControls.jsx';
@@ -6,9 +7,13 @@ import ChatPanel from '../components/ChatPanel.jsx';
 import BackgammonEngine from 'backgammon-engine';
 
 export default function Game() {
+  const [searchParams] = useSearchParams();
+  const roomId = searchParams.get('room');
+  const navigate = useNavigate();
   const [game] = useState(() => new BackgammonEngine());
   const [board, setBoard] = useState(game.board || []);
   const [dice, setDice] = useState(game.dice || []);
+  const [chemistry, setChemistry] = useState(0);
 
   const roll = () => {
     if (game.rollDice) {
@@ -26,14 +31,31 @@ export default function Game() {
     }
   };
 
+  const handleInteraction = () =>
+    setChemistry((c) => Math.min(100, c + 10));
+
+  const endGame = () => {
+    localStorage.setItem(
+      'matchSummary',
+      JSON.stringify({ chemistry, roomId, score: game.score ?? 0 })
+    );
+    navigate('/post-match');
+  };
+
   return (
     <div style={{ display: 'flex' }}>
       <div style={{ flex: 1 }}>
         <Board board={board} />
         <Dice values={dice} />
-        <GameControls onRoll={roll} onReset={reset} />
+        <GameControls onRoll={roll} onReset={reset} onEnd={endGame} />
+        <div style={{ marginTop: '1rem' }}>
+          <label>
+            Chemistry
+            <progress value={chemistry} max="100" style={{ marginLeft: '0.5rem' }} />
+          </label>
+        </div>
       </div>
-      <ChatPanel />
+      <ChatPanel roomId={roomId} onInteraction={handleInteraction} />
     </div>
   );
 }

--- a/src/pages/Lobby.jsx
+++ b/src/pages/Lobby.jsx
@@ -1,3 +1,42 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
 export default function Lobby() {
-  return <h1>Lobby</h1>;
+  const [ws, setWs] = useState(null);
+  const [status, setStatus] = useState('idle');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const socket = new WebSocket('ws://localhost:8080');
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === 'match') {
+          navigate(`/game?room=${data.roomId}`);
+        }
+      } catch {
+        // ignore
+      }
+    };
+    setWs(socket);
+    return () => socket.close();
+  }, [navigate]);
+
+  const joinLobby = () => {
+    if (ws) {
+      ws.send(JSON.stringify({ type: 'join-lobby' }));
+      setStatus('waiting');
+    }
+  };
+
+  return (
+    <div>
+      <h1>Lobby</h1>
+      {status === 'waiting' ? (
+        <p>Waiting for an opponent...</p>
+      ) : (
+        <button onClick={joinLobby}>Find Match</button>
+      )}
+    </div>
+  );
 }

--- a/src/pages/PostMatch.jsx
+++ b/src/pages/PostMatch.jsx
@@ -1,3 +1,36 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
 export default function PostMatch() {
-  return <h1>Post Match Summary</h1>;
+  const [summary, setSummary] = useState(null);
+
+  useEffect(() => {
+    try {
+      setSummary(JSON.parse(localStorage.getItem('matchSummary')));
+    } catch {
+      setSummary(null);
+    }
+  }, []);
+
+  if (!summary) {
+    return <p>No match summary available.</p>;
+  }
+
+  return (
+    <div>
+      <h1>Post Match Summary</h1>
+      <p>Score: {summary.score}</p>
+      <div>
+        <label>
+          Chemistry
+          <progress value={summary.chemistry} max="100" style={{ marginLeft: '0.5rem' }} />
+        </label>
+      </div>
+      {summary.roomId && (
+        <p>
+          <Link to={`/game?room=${summary.roomId}`}>Continue Conversation</Link>
+        </p>
+      )}
+    </div>
+  );
 }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -8,10 +8,12 @@ export default function Profile() {
           name: '',
           interests: '',
           playStyle: 'casual',
+          bio: '',
+          favoriteGames: '',
         }
       );
     } catch {
-      return { name: '', interests: '', playStyle: 'casual' };
+      return { name: '', interests: '', playStyle: 'casual', bio: '', favoriteGames: '' };
     }
   });
   const [editing, setEditing] = useState(!profile.name);
@@ -45,11 +47,23 @@ export default function Profile() {
         </div>
         <div>
           <label>
+            Favorite Games
+            <input name="favoriteGames" value={profile.favoriteGames} onChange={handleChange} />
+          </label>
+        </div>
+        <div>
+          <label>
             Play Style
             <select name="playStyle" value={profile.playStyle} onChange={handleChange}>
               <option value="casual">Casual</option>
               <option value="competitive">Competitive</option>
             </select>
+          </label>
+        </div>
+        <div>
+          <label>
+            Bio
+            <textarea name="bio" value={profile.bio} onChange={handleChange} />
           </label>
         </div>
         <button type="submit">Save Profile</button>
@@ -61,7 +75,9 @@ export default function Profile() {
     <div>
       <h1>{profile.name}</h1>
       {profile.interests && <p>Interests: {profile.interests}</p>}
+      {profile.favoriteGames && <p>Favorite games: {profile.favoriteGames}</p>}
       <p>Play style: {profile.playStyle}</p>
+      {profile.bio && <p>{profile.bio}</p>}
       <button onClick={() => setEditing(true)}>Edit Profile</button>
     </div>
   );


### PR DESCRIPTION
## Summary
- capture additional profile details like bio and favorite games
- add WebSocket lobby and matchmaking server with front-end integration
- show chemistry progress and post-match summary with option to continue chat

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/backgammon-engine)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6da493684832d815bd761b43af996