### PR TITLE
Fix app load by referencing source entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,10 +75,6 @@
       })();
     </script>
     <!-- If the app fails to load, try clearing your browser cache -->
-    <script
-      type="module"
-      crossorigin
-      src="./public/assets/index-BXQJKMwX.js"
-    ></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load React application via `/src/main.jsx` so that it actually mounts instead of showing only debug buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ddc1f830832d93e333d9f60287a3