### PR TITLE
Fix asset path for built bundle import

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,11 +77,11 @@
     <!-- If the app fails to load, try clearing your browser cache -->
     <script type="module">
       console.log('Attempting to load built bundle...');
-      import('/assets/index-BXQJKMwX.js')
+      import('./assets/index-BXQJKMwX.js')
         .then(() => console.log('Loaded built bundle successfully.'))
         .catch((err) => {
           console.error('Failed to load built bundle, falling back to source.', err);
-          import('/src/main.jsx').then(() =>
+          import('./src/main.jsx').then(() =>
             console.log('Loaded source entry.')
           );
         });


### PR DESCRIPTION
## Summary
- use relative paths for built bundle and source fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6e48e4f74832d990d21e82a59d1fe