### PR TITLE
Handle empty render from built bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,14 +77,23 @@
     <!-- If the app fails to load, try clearing your browser cache -->
     <script type="module">
       console.log('Attempting to load built bundle...');
+      const fallbackToSource = (err) => {
+        console.error('Failed to load built bundle, falling back to source.', err);
+        import('./src/main.jsx').then(() =>
+          console.log('Loaded source entry.')
+        );
+      };
+
       import('./assets/index-BXQJKMwX.js')
-        .then(() => console.log('Loaded built bundle successfully.'))
-        .catch((err) => {
-          console.error('Failed to load built bundle, falling back to source.', err);
-          import('./src/main.jsx').then(() =>
-            console.log('Loaded source entry.')
-          );
-        });
+        .then(() => {
+          console.log('Loaded built bundle successfully.');
+          setTimeout(() => {
+            if (!document.getElementById('root').hasChildNodes()) {
+              fallbackToSource(new Error('Built bundle rendered nothing.'));
+            }
+          }, 1000);
+        })
+        .catch(fallbackToSource);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- detect when built bundle loads but fails to render and fallback to source entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e64a47b0832db821ac7a490967fe