### PR TITLE
Handle index route for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,25 +75,30 @@
       })();
     </script>
     <!-- If the app fails to load, try clearing your browser cache -->
-    <script type="module">
-      console.log('Attempting to load built bundle...');
-      const fallbackToSource = (err) => {
-        console.error('Failed to load built bundle, falling back to source.', err);
-        import('./src/main.jsx').then(() =>
-          console.log('Loaded source entry.')
-        );
-      };
+      <script type="module">
+        const { pathname } = window.location;
+        if (pathname.endsWith('index.html')) {
+          history.replaceState(null, '', pathname.replace(/index.html$/, ''));
+        }
 
-      import('./assets/index-BXQJKMwX.js')
-        .then(() => {
-          console.log('Loaded built bundle successfully.');
-          setTimeout(() => {
-            if (!document.getElementById('root').hasChildNodes()) {
-              fallbackToSource(new Error('Built bundle rendered nothing.'));
-            }
-          }, 1000);
-        })
-        .catch(fallbackToSource);
-    </script>
-  </body>
-</html>
+        console.log('Attempting to load built bundle...');
+        const fallbackToSource = (err) => {
+          console.error('Failed to load built bundle, falling back to source.', err);
+          import('./src/main.jsx').then(() =>
+            console.log('Loaded source entry.')
+          );
+        };
+
+        import('./assets/index-BXQJKMwX.js')
+          .then(() => {
+            console.log('Loaded built bundle successfully.');
+            setTimeout(() => {
+              if (!document.getElementById('root').hasChildNodes()) {
+                fallbackToSource(new Error('Built bundle rendered nothing.'));
+              }
+            }, 1000);
+          })
+          .catch(fallbackToSource);
+      </script>
+    </body>
+  </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import MainLayout from './layouts/MainLayout.jsx';
 import Home from './pages/Home.jsx';
 import Profile from './pages/Profile.jsx';
@@ -20,6 +20,7 @@ export default function App() {
         <Route path="game" element={<Game />} />
         <Route path="post-match" element={<PostMatch />} />
       </Route>
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- Redirect `index.html` requests to the root path before loading bundle to ensure rendering on GitHub Pages
- Add catch‑all router redirect so unknown paths fall back to the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6f2197b7c832dbbbffc54f4c3e2f2