### PR TITLE
feat: display board with tailwind styling

### DIFF
--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,15 +1,40 @@
 import Checker from './Checker.jsx';
 
+// Render a 24-point board. If no board data is provided, we fall back to an
+// empty board so the layout is still visible.
+const EMPTY_BOARD = Array.from({ length: 24 }, () => ({ color: null, count: 0 }));
+
 export default function Board({ board = [] }) {
+  const points = board.length ? board : EMPTY_BOARD;
+  const topRow = points.slice(0, 12);
+  const bottomRow = points.slice(12).reverse();
+
   return (
-    <div className="board">
-      {board.map((point, index) => (
-        <div key={index} className="point">
-          {Array.from({ length: point.count }).map((_, i) => (
-            <Checker key={i} color={point.color} />
-          ))}
-        </div>
-      ))}
+    <div className="p-4 bg-green-800 rounded-md space-y-2">
+      <div className="grid grid-cols-12 gap-1">
+        {topRow.map((point, index) => (
+          <div
+            key={index}
+            className="flex flex-col-reverse justify-start items-center h-32 bg-amber-200"
+          >
+            {Array.from({ length: point.count }).map((_, i) => (
+              <Checker key={i} color={point.color} />
+            ))}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-12 gap-1">
+        {bottomRow.map((point, index) => (
+          <div
+            key={index + 12}
+            className="flex flex-col justify-start items-center h-32 bg-amber-200"
+          >
+            {Array.from({ length: point.count }).map((_, i) => (
+              <Checker key={i} color={point.color} />
+            ))}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Checker.jsx
+++ b/src/components/Checker.jsx
@@ -1,3 +1,10 @@
 export default function Checker({ color }) {
-  return <div className={`checker checker-${color}`} />;
+  const colorClass =
+    color === 'white' ? 'bg-white' : color === 'black' ? 'bg-black' : 'bg-transparent';
+
+  return (
+    <div
+      className={`w-6 h-6 rounded-full border border-gray-700 mb-1 ${colorClass}`}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- render a full 24-point board with Tailwind-based layout
- style checkers and add fallback board when no data is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6ffe8eb08832db97d5e27b587a72a