### PR TITLE
Fix navigation paths for GitHub Pages

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -13,16 +13,16 @@ export default function NavBar() {
       <NavLink to="/" className={linkClass} end>
         Home
       </NavLink>
-      <NavLink to="/profile" className={linkClass}>
+      <NavLink to="profile" className={linkClass}>
         Profile
       </NavLink>
-      <NavLink to="/lobby" className={linkClass}>
+      <NavLink to="lobby" className={linkClass}>
         Lobby
       </NavLink>
-      <NavLink to="/game" className={linkClass}>
+      <NavLink to="game" className={linkClass}>
         Game
       </NavLink>
-      <NavLink to="/post-match" className={linkClass}>
+      <NavLink to="post-match" className={linkClass}>
         Post Match
       </NavLink>
     </nav>


### PR DESCRIPTION
## Summary
- Use relative paths in navigation links so pages mount correctly on GitHub Pages

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/backgammon-engine)*

------
https://chatgpt.com/codex/tasks/task_e_68a70a750e18832da4423fa3b9f8a9bf