### PR TITLE
feat: add PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # SingleBackgammon
+
+Single Backgammon web client.
+
+## PWA
+
+The app can be installed as a Progressive Web App for offline use.

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" fill="#000"/>
+  <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-size="128" fill="#fff">B</text>
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#000"/>
+  <text x="50%" y="50%" dy=".35em" text-anchor="middle" font-size="384" fill="#fff">B</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Single Backgammon</title>
+    <link rel="icon" href="icons/icon-192.svg" type="image/svg+xml" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="theme-color" content="#ffffff" />
     <script>
       (function () {
         window.logs = [];
@@ -78,11 +81,27 @@
             const cacheNames = await caches.keys();
             await Promise.all(cacheNames.map((name) => caches.delete(name)));
           }
+          if ('serviceWorker' in navigator) {
+            const registrations = await navigator.serviceWorker.getRegistrations();
+            for (const registration of registrations) {
+              await registration.unregister();
+            }
+          }
           localStorage.clear();
           sessionStorage.clear();
           location.reload();
         });
       })();
+    </script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker
+          .register('sw.js')
+          .then(() => console.log('Service Worker registered.'))
+          .catch((err) =>
+            console.error('Service Worker registration failed:', err)
+          );
+      }
     </script>
     <!-- If the app fails to load, try clearing your browser cache -->
       <script type="module">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Single Backgammon",
+  "short_name": "Backgammon",
+  "display": "standalone",
+  "start_url": "/SingleBackgammon/",
+  "scope": "/SingleBackgammon/",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'singlebackgammon-cache-v1';
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+  event.respondWith(
+    caches.open(CACHE_NAME).then((cache) =>
+      fetch(event.request)
+        .then((response) => {
+          cache.put(event.request, response.clone());
+          return response;
+        })
+        .catch(() => cache.match(event.request))
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest and service worker with offline caching
- register service worker and manifest in HTML
- document new PWA capabilities

## Testing
- `npm install` *(fails: 403 Forbidden - backgammon-engine)*
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a711c517bc832da2782eb6883e4257