### PR TITLE
Use local Backgammon engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lobby": "node server.js"
   },
   "dependencies": {
-    "backgammon-engine": "^1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",

--- a/src/engine/BackgammonEngine.js
+++ b/src/engine/BackgammonEngine.js
@@ -1,0 +1,19 @@
+export default class BackgammonEngine {
+  constructor() {
+    this.reset();
+    this.score = 0;
+  }
+
+  rollDice() {
+    this.dice = [this.#rollDie(), this.#rollDie()];
+  }
+
+  #rollDie() {
+    return Math.floor(Math.random() * 6) + 1;
+  }
+
+  reset() {
+    this.board = Array.from({ length: 24 }, () => ({ color: null, count: 0 }));
+    this.dice = [];
+  }
+}

--- a/src/pages/Game.jsx
+++ b/src/pages/Game.jsx
@@ -4,7 +4,7 @@ import Board from '../components/Board.jsx';
 import Dice from '../components/Dice.jsx';
 import GameControls from '../components/GameControls.jsx';
 import ChatPanel from '../components/ChatPanel.jsx';
-import BackgammonEngine from 'backgammon-engine';
+import BackgammonEngine from '../engine/BackgammonEngine.js';
 
 export default function Game() {
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Replace external `backgammon-engine` dependency with a simple local implementation
- Update Game page to use the local engine for dice and board state
- Remove unavailable `backgammon-engine` dependency from package.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a714708184832dad6a549d35dd9b5f