### PR TITLE
Initialize board state on game load

### DIFF
--- a/src/engine/BackgammonEngine.js
+++ b/src/engine/BackgammonEngine.js
@@ -13,7 +13,25 @@ export default class BackgammonEngine {
   }
 
   reset() {
+    // Set up a standard backgammon starting position. The board is
+    // represented as an array of 24 points, indexed from 0–23. For the
+    // purposes of this demo engine the exact orientation isn't critical,
+    // we simply mirror the traditional layout so the board doesn't appear
+    // empty when a game starts.
     this.board = Array.from({ length: 24 }, () => ({ color: null, count: 0 }));
+
+    // White pieces
+    this.board[0] = { color: 'white', count: 2 };
+    this.board[11] = { color: 'white', count: 5 };
+    this.board[16] = { color: 'white', count: 3 };
+    this.board[18] = { color: 'white', count: 5 };
+
+    // Black pieces
+    this.board[23] = { color: 'black', count: 2 };
+    this.board[12] = { color: 'black', count: 5 };
+    this.board[7] = { color: 'black', count: 3 };
+    this.board[5] = { color: 'black', count: 5 };
+
     this.dice = [];
   }
 }


### PR DESCRIPTION
## Summary
- Initialize standard backgammon piece layout when a game starts
- Prevents game screen from appearing empty on first load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a71725b710832db43f797cbf9d88d5