### PR TITLE
Preserve console logs in production

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -6,5 +6,11 @@ export default defineConfig({
   plugins: [react()],
   build: {
     outDir: 'public',
+    // Disable minification and tree-shaking so console logs remain in the
+    // production bundle, making it easier to debug issues in the deployed app.
+    minify: false,
+    rollupOptions: {
+      treeshake: false,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- disable minification and tree-shaking in Vite build to retain runtime console logs

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a726c46ecc832d820f25cfc26fd798