### PR TITLE
Capture window errors in console log

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,6 +17,15 @@
           window.logs.push('ERROR: ' + args.join(' '));
           origError.apply(console, args);
         };
+        window.addEventListener('error', (event) => {
+          window.logs.push('ERROR: ' + event.message);
+          origError(event.message);
+        });
+        window.addEventListener('unhandledrejection', (event) => {
+          const message = (event.reason && event.reason.message) || event.reason;
+          window.logs.push('ERROR: Unhandled promise rejection: ' + message);
+          origError('Unhandled promise rejection:', message);
+        });
       })();
     </script>
     <script

--- a/index.html
+++ b/index.html
@@ -20,6 +20,15 @@
           window.logs.push('ERROR: ' + args.join(' '));
           origError.apply(console, args);
         };
+        window.addEventListener('error', (event) => {
+          window.logs.push('ERROR: ' + event.message);
+          origError(event.message);
+        });
+        window.addEventListener('unhandledrejection', (event) => {
+          const message = (event.reason && event.reason.message) || event.reason;
+          window.logs.push('ERROR: Unhandled promise rejection: ' + message);
+          origError('Unhandled promise rejection:', message);
+        });
       })();
       console.log('index.html: initial pathname', window.location.pathname);
     </script>


### PR DESCRIPTION
## Summary
- Capture unhandled errors and promise rejections so they appear in the in-app console window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72aeca794832da6905ed20d6c0d2e