### PR TITLE
feat: add basic React PWA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,0 +1,15 @@
+const App = () => (
+  <div className="text-center">
+    <h1 className="text-3xl font-bold mb-4">SingleBackgammon</h1>
+    <button className="px-4 py-2 bg-blue-500 text-white rounded">Test Button</button>
+  </div>
+);
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./service-worker.js');
+  });
+}

--- a/index.html
+++ b/index.html
@@ -5,11 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SingleBackgammon</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="manifest" href="./manifest.json" />
 </head>
 <body class="flex items-center justify-center min-h-screen bg-gray-100">
-  <div class="text-center">
-    <h1 class="text-3xl font-bold mb-4">SingleBackgammon</h1>
-    <button class="px-4 py-2 bg-blue-500 text-white rounded">Test Button</button>
-  </div>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="./app.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "SingleBackgammon",
+  "short_name": "SingleBackgammon",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' fill='%23000'/></svg>",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><rect width='512' height='512' fill='%23000'/></svg>",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'single-backgammon-cache-v1';
+const urlsToCache = [
+  './',
+  './index.html',
+  './app.js',
+  './manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- scaffold basic React app
- add service worker and manifest for offline support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a738ede390832d81046e07e5073cd0