### PR TITLE
Fix JSX syntax error in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,21 @@
-const App = () => (
-  <div className="text-center">
-    <h1 className="text-3xl font-bold mb-4">SingleBackgammon</h1>
-    <button className="px-4 py-2 bg-blue-500 text-white rounded">Test Button</button>
-  </div>
-);
+const App = () =>
+  React.createElement(
+    'div',
+    { className: 'text-center' },
+    React.createElement(
+      'h1',
+      { className: 'text-3xl font-bold mb-4' },
+      'SingleBackgammon'
+    ),
+    React.createElement(
+      'button',
+      { className: 'px-4 py-2 bg-blue-500 text-white rounded' },
+      'Test Button'
+    )
+  );
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(React.createElement(App));
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- Replace JSX with `React.createElement` calls to avoid syntax errors without Babel
- Update render call accordingly

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73affffe8832d803fef0ff7ebe155