### PR TITLE
feat: add board rendering with starting checkers

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,18 +1,92 @@
-const App = () =>
-  React.createElement(
+// Represents a single point on the board
+const Point = (point, index) => {
+  const isTop = index < 12;
+  const colorClass = index % 2 === 0
+    ? isTop
+      ? 'border-b-yellow-600'
+      : 'border-t-yellow-600'
+    : isTop
+      ? 'border-b-orange-700'
+      : 'border-t-orange-700';
+
+  const checkers = [];
+  for (let i = 0; i < point.count; i++) {
+    checkers.push(
+      React.createElement('div', {
+        key: i,
+        className: `w-6 h-6 rounded-full border border-gray-800 mb-1 ${
+          point.color === 'white' ? 'bg-white' : 'bg-black'
+        }`,
+      })
+    );
+  }
+
+  return React.createElement(
     'div',
-    { className: 'text-center' },
+    {
+      'data-point': index,
+      className: 'relative w-8 h-32 flex justify-center items-center',
+    },
+    React.createElement('div', {
+      className: `absolute w-0 h-0 border-l-[16px] border-r-[16px] ${
+        isTop ? 'border-b-[96px]' : 'border-t-[96px]'
+      } border-l-transparent border-r-transparent ${colorClass} ${
+        isTop ? 'top-0' : 'bottom-0'
+      }`,
+    }),
     React.createElement(
-      'h1',
-      { className: 'text-3xl font-bold mb-4' },
-      'SingleBackgammon'
-    ),
-    React.createElement(
-      'button',
-      { className: 'px-4 py-2 bg-blue-500 text-white rounded' },
-      'Test Button'
+      'div',
+      {
+        className: `absolute w-full h-full flex flex-col ${
+          isTop ? 'justify-end' : 'justify-start'
+        } items-center ${isTop ? 'bottom-0' : 'top-0'}`,
+      },
+      checkers
     )
   );
+};
+
+// Board component rendering 24 points
+const Board = () => {
+  const initialPoints = React.useMemo(() => {
+    const pts = Array(24)
+      .fill(null)
+      .map(() => ({ color: null, count: 0 }));
+
+    // White checkers
+    pts[0] = { color: 'white', count: 5 }; // point 13
+    pts[11] = { color: 'white', count: 2 }; // point 24
+    pts[16] = { color: 'white', count: 3 }; // point 8
+    pts[18] = { color: 'white', count: 5 }; // point 6
+
+    // Black checkers
+    pts[23] = { color: 'black', count: 2 }; // point 1
+    pts[12] = { color: 'black', count: 5 }; // point 12
+    pts[4] = { color: 'black', count: 3 }; // point 17
+    pts[6] = { color: 'black', count: 5 }; // point 19
+
+    return pts;
+  }, []);
+
+  const [points] = React.useState(initialPoints);
+
+  return React.createElement(
+    'div',
+    { className: 'mx-auto' },
+    React.createElement(
+      'div',
+      { className: 'grid grid-cols-12 gap-1' },
+      points.slice(0, 12).map((p, i) => Point(p, i))
+    ),
+    React.createElement(
+      'div',
+      { className: 'grid grid-cols-12 gap-1' },
+      points.slice(12).map((p, i) => Point(p, i + 12))
+    )
+  );
+};
+
+const App = () => React.createElement(Board);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(React.createElement(App));


### PR DESCRIPTION
## Summary
- implement Backgammon board component rendering 24 triangles
- initialize point state with standard starting checker positions
- display board in App

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server 8000` & `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a73ea31c08832da90f48553fb7da1a