### PR TITLE
Fix missing key prop in Board rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ const Point = (point, index) => {
   return React.createElement(
     'div',
     {
+      key: index,
       'data-point': index,
       className: 'relative w-8 h-32 flex justify-center items-center',
     },


### PR DESCRIPTION
## Summary
- assign unique keys to board point elements

## Testing
- `npm test` (fails: could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a9bd950ae0832da7d725a47504bea4