### PR TITLE
Fix boardgame.io script reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <div id="root"></div>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/boardgame.io/dist/boardgameio.umd.js"></script>
+  <script src="https://unpkg.com/boardgame.io/dist/boardgameio.min.js"></script>
   <script src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct boardgame.io CDN path to use minified build

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c6061524832d8bb1ca0a5aad19cb