### PR TITLE
fix: load boardgame.io via esm

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import { Client } from 'https://esm.sh/boardgame.io/client';
+
 // Represents a single point on the board
 const Point = (point, index, selected, onClick) => {
   const isTop = index < 12;
@@ -182,8 +184,6 @@ const Board = ({ G, ctx, moves, events }) => {
     )
   );
 };
-
-const { Client } = boardgameio;
 
 const App = Client({ game: Backgammon, board: Board });
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <div id="root"></div>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
-  <script src="https://unpkg.com/boardgame.io/dist/boardgameio.min.js"></script>
-  <script src="./app.js"></script>
+  <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use ESM import for boardgame.io client
- mark app.js as module and drop global boardgameio dependency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c7463394832d8cfee5fb6f2bb7d5