### PR TITLE
Enable boardgame.io random plugin

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 import { Client } from 'https://esm.sh/boardgame.io/client';
+import { Random } from 'https://esm.sh/boardgame.io/random';
 
 // Represents a single point on the board
 const Point = (point, index, selected, onClick) => {
@@ -107,6 +108,7 @@ const Backgammon = {
       G.dice = [ctx.random.D6(), ctx.random.D6()];
     },
   },
+  plugins: [Random()],
 };
 
 // Board component rendering 24 points using game state


### PR DESCRIPTION
## Summary
- fix ctx.random undefined by importing Random plugin
- register Random plugin in Backgammon game

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c8bb769c832db266e5d2c44c9635