### PR TITLE
Use built-in random plugin to avoid CDN 404

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,4 @@
 import { Client } from 'https://esm.sh/boardgame.io/client';
-import { Random } from 'https://esm.sh/boardgame.io/random';
 
 // Represents a single point on the board
 const Point = (point, index, selected, onClick) => {
@@ -108,7 +107,6 @@ const Backgammon = {
       G.dice = [ctx.random.D6(), ctx.random.D6()];
     },
   },
-  plugins: [Random()],
 };
 
 // Board component rendering 24 points using game state


### PR DESCRIPTION
## Summary
- remove external `Random` plugin import and registration

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c9b28970832d8348d5ea41f517a8