### PR TITLE
fix: use Math.random for dice rolls

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,7 +104,10 @@ const Backgammon = {
   },
   turn: {
     onBegin(G, ctx) {
-      G.dice = [ctx.random.D6(), ctx.random.D6()];
+      // ctx.random is undefined when the Random plugin isn't used,
+      // so roll dice using Math.random instead to avoid runtime errors.
+      const rollDie = () => Math.floor(Math.random() * 6) + 1;
+      G.dice = [rollDie(), rollDie()];
     },
   },
 };


### PR DESCRIPTION
## Summary
- avoid undefined `ctx.random` by rolling dice with Math.random

## Testing
- ⚠️ `npm test` (missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a9cb1b7c88832da28c4d5eb3dc4750