### PR TITLE
Add error boundary to handle runtime errors

### DIFF
--- a/app.js
+++ b/app.js
@@ -193,8 +193,40 @@ const Board = ({ G, ctx, moves, events }) => {
 
 const App = Client({ game: Backgammon, board: Board });
 
+// Simple error boundary to surface runtime problems in the UI
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, message: error?.message || 'An unexpected error occurred.' };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return React.createElement(
+        'div',
+        {
+          className:
+            'p-4 m-4 bg-red-100 text-red-800 border border-red-400 rounded',
+        },
+        `Error: ${this.state.message}`
+      );
+    }
+    return this.props.children;
+  }
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(React.createElement(App));
+root.render(
+  React.createElement(ErrorBoundary, null, React.createElement(App))
+);
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- wrap the boardgame.io client with a React error boundary so unexpected errors display a user-friendly message

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9ccebfb44832da939a2a7bc8e0209