### PR TITLE
Improve error logging in console capture

### DIFF
--- a/console-capture.js
+++ b/console-capture.js
@@ -7,7 +7,15 @@
     const message = args
       .map((arg) => {
         try {
-          return typeof arg === 'string' ? arg : JSON.stringify(arg);
+          if (arg instanceof Error) {
+            return arg.stack || arg.message || String(arg);
+          } else if (typeof arg === 'object' && arg !== null) {
+            if (arg.stack || arg.message) {
+              return `${arg.message || ''}${arg.stack ? `\n${arg.stack}` : ''}`.trim();
+            }
+            return JSON.stringify(arg);
+          }
+          return String(arg);
         } catch (e) {
           return String(arg);
         }


### PR DESCRIPTION
## Summary
- handle Error objects in console-capture to surface stack or message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf2e0980832da18fed8644902a69