### PR TITLE
Load React via ESM to avoid duplicate React instances

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,13 @@
-// Import the React-specific client from boardgame.io.
-// Using the generic client ("boardgame.io/client") returns a plain object
-// which causes React to warn that the element type is invalid.
+// Import React and ReactDOM as ES modules to ensure boardgame.io shares the
+// same React instance. Mixing UMD and ESM builds can lead to runtime errors
+// like "Objects are not valid as a React child" because multiple copies of
+// React get loaded.  Loading everything from esm.sh keeps dependencies
+// consistent across the app.
+import React from 'https://esm.sh/react@18.3.1';
+import ReactDOM from 'https://esm.sh/react-dom@18.3.1/client';
+// Import the React-specific client from boardgame.io. Using the generic
+// client ("boardgame.io/client") returns a plain object which causes React
+// to warn that the element type is invalid.
 import { Client } from 'https://esm.sh/boardgame.io/react';
 
 // Represents a single point on the board.

--- a/index.html
+++ b/index.html
@@ -10,8 +10,6 @@
 </head>
 <body class="flex items-center justify-center min-h-screen bg-gray-100">
   <div id="root"></div>
-  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script type="module" src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load React and ReactDOM as ES modules and keep boardgame.io client in the same import chain
- Remove UMD React scripts from index.html to prevent mismatched React copies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d1392c28832d866181f4384f8642