### PR TITLE
Fix board triangle alignment

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ const Point = ({ point, index, selected, onClick }) => {
         isTop ? 'border-b-[96px]' : 'border-t-[96px]'
       } border-l-transparent border-r-transparent ${colorClass} ${
         isTop ? 'top-0' : 'bottom-0'
-      }`,
+      } left-1/2 -translate-x-1/2`,
     }),
     React.createElement(
       'div',


### PR DESCRIPTION
## Summary
- Center each point triangle within its grid cell to line up the board with the green selection overlay

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d5f142d4832d95de673501d51ed5