### PR TITLE
Roll dice automatically at turn start

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,6 +120,13 @@ const createInitialPoints = () => {
 // Game definition handled by boardgame.io
 const Backgammon = {
   setup: () => ({ points: createInitialPoints(), dice: [] }),
+  turn: {
+    onBegin(G) {
+      const d1 = rollDie();
+      const d2 = rollDie();
+      G.dice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
+    },
+  },
   moves: {
     moveChecker(G, ctx, from, to) {
       const color = ctx.currentPlayer === '0' ? 'white' : 'black';
@@ -145,11 +152,6 @@ const Backgammon = {
       if (dieIndex >= 0) G.dice.splice(dieIndex, 1);
       if (G.dice.length === 0) ctx.events.endTurn();
     },
-    rollDice(G) {
-      const d1 = rollDie();
-      const d2 = rollDie();
-      G.dice = d1 === d2 ? [d1, d1, d1, d1] : [d1, d2];
-    },
   },
 };
 
@@ -173,10 +175,6 @@ const Board = ({ G, ctx, moves, events }) => {
   };
 
   React.useEffect(() => {
-    if (!Array.isArray(G.dice) || G.dice.length === 0) {
-      moves.rollDice();
-      return;
-    }
     if (ctx.currentPlayer === '1') {
       const possible = [];
       for (let i = 0; i < 24; i++) {


### PR DESCRIPTION
## Summary
- Roll new dice at the beginning of each turn via boardgame.io `turn.onBegin`
- Remove manual dice rolling logic from board component

## Testing
- `node --check app.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d9c46f20832dac0bde728f653b48