### PR TITLE
Remove autoplay option from how-to-play card

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -99,17 +99,6 @@ const Board = ({ G, ctx, moves, events }) => {
               onClick: () => setShowInstructions(false),
             },
             'Close'
-          ),
-          React.createElement(
-            'button',
-            {
-              className: 'mt-2 ml-2 px-4 py-2 bg-green-500 text-white rounded',
-              onClick: () => {
-                setShowInstructions(false);
-                setAutoPlay(true);
-              },
-            },
-            'Autoplay'
           )
         )
       ),


### PR DESCRIPTION
## Summary
- Remove redundant Autoplay button from the in-game "How to Play" overlay

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e1ab0b18832d9215f658b35621aa