### PR TITLE
Highlight legal destinations for selected checkers

### DIFF
--- a/components/Point.js
+++ b/components/Point.js
@@ -1,6 +1,6 @@
 import React from 'https://esm.sh/react@18.3.1';
 
-const Point = ({ point, index, selected, onClick }) => {
+const Point = ({ point, index, selected, highlighted, onClick }) => {
   const isTop = index < 12;
   const colorClass = index % 2 === 0
     ? isTop
@@ -29,7 +29,7 @@ const Point = ({ point, index, selected, onClick }) => {
       onClick,
       className: `relative w-8 h-32 flex justify-center items-center cursor-pointer ${
         selected ? 'bg-green-200' : ''
-      }`,
+      } ${highlighted ? 'bg-blue-200' : ''}`,
     },
     React.createElement('div', {
       className: `absolute w-0 h-0 border-l-[16px] border-r-[16px] ${


### PR DESCRIPTION
## Summary
- track a checker selection and compute legal destination points
- highlight possible moves on the board and clear highlights on turn change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e1f50adc832db3151e417293b4a6