### PR TITLE
Add Enter key support for rolling dice

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -102,6 +102,20 @@ const Board = ({ G, ctx, moves, events }) => {
     setPossibleMoves([]);
   }, [ctx.turn]);
 
+  React.useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Enter') {
+        if (stepPlay) {
+          makeAIMove();
+        } else if (!autoPlay) {
+          events.endTurn();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [autoPlay, stepPlay, events, makeAIMove]);
+
   return React.createElement(
     'div',
     { className: 'mx-auto text-center' },


### PR DESCRIPTION
## Summary
- Roll new dice when pressing Enter by listening for keydown
- Enter triggers AI `Next` action or end turn depending on mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e3b968cc832da960f2c87673d5b1