### PR TITLE
Add board point numbers for orientation

### DIFF
--- a/components/Point.js
+++ b/components/Point.js
@@ -9,6 +9,7 @@ const Point = ({ point, index, selected, highlighted, onClick }) => {
     : isTop
       ? 'border-b-orange-700'
       : 'border-t-orange-700';
+  const number = index < 12 ? index + 13 : 24 - index;
 
   const checkers = [];
   for (let i = 0; i < point.count; i++) {
@@ -46,6 +47,15 @@ const Point = ({ point, index, selected, highlighted, onClick }) => {
         } items-center ${isTop ? 'bottom-0' : 'top-0'} pointer-events-none`,
       },
       ...checkers
+    ),
+    React.createElement(
+      'span',
+      {
+        className: `absolute text-xs text-gray-600 ${
+          isTop ? 'top-1' : 'bottom-1'
+        } left-1 pointer-events-none`,
+      },
+      number
     )
   );
 };


### PR DESCRIPTION
## Summary
- show point numbers on the board to indicate playing direction

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f07f791c832dbc4e704ff2d8407d