### PR TITLE
Highlight origin and destination of last move

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -19,6 +19,7 @@ const Board = () => {
   const [showInstructions, setShowInstructions] = React.useState(false);
   const [autoPlay, setAutoPlay] = React.useState(false);
   const [stepPlay, setStepPlay] = React.useState(false);
+  const [lastMove, setLastMove] = React.useState(null);
 
   const endTurn = () => {
     setCurrentPlayer((p) => (p === '0' ? '1' : '0'));
@@ -31,6 +32,7 @@ const Board = () => {
     if (!result.points) return;
     setPoints(result.points);
     setDice(result.dice);
+    setLastMove({ from, to });
     if (result.dice.length === 0) endTurn();
     const winner = getWinner(result.points);
     if (winner) setGameover({ winner });
@@ -330,6 +332,8 @@ const Board = () => {
           index: i,
           selected: selected === i,
           highlighted: possibleMoves.includes(i),
+          movedFrom: lastMove && lastMove.from === i,
+          movedTo: lastMove && lastMove.to === i,
           onClick: () => handlePointClick(i),
         })
       )
@@ -344,6 +348,8 @@ const Board = () => {
           index: i + 12,
           selected: selected === i + 12,
           highlighted: possibleMoves.includes(i + 12),
+          movedFrom: lastMove && lastMove.from === i + 12,
+          movedTo: lastMove && lastMove.to === i + 12,
           onClick: () => handlePointClick(i + 12),
         })
       )

--- a/components/Point.js
+++ b/components/Point.js
@@ -1,6 +1,14 @@
 import React from 'https://esm.sh/react@18.3.1';
 
-const Point = ({ point, index, selected, highlighted, onClick }) => {
+const Point = ({
+  point,
+  index,
+  selected,
+  highlighted,
+  movedFrom,
+  movedTo,
+  onClick,
+}) => {
   const isTop = index < 12;
   const colorClass = index % 2 === 0
     ? isTop
@@ -30,7 +38,9 @@ const Point = ({ point, index, selected, highlighted, onClick }) => {
       onClick,
       className: `relative w-8 h-32 flex justify-center items-center cursor-pointer ${
         selected ? 'bg-green-200' : ''
-      } ${highlighted ? 'bg-blue-200' : ''}`,
+      } ${highlighted ? 'bg-blue-200' : ''} ${movedFrom ? 'bg-red-200' : ''} ${
+        movedTo ? 'bg-yellow-200' : ''
+      }`,
     },
     React.createElement('div', {
       className: `absolute w-0 h-0 border-l-[16px] border-r-[16px] ${


### PR DESCRIPTION
## Summary
- Track the last move on the board and highlight the origin and destination points
- Allow Point components to render moved-from and moved-to states for better move visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f2a0e44c832db207cc58b6906ebc