### PR TITLE
Simplify game logic for internal board state

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -28,7 +28,7 @@ const Board = () => {
 
   const moveChecker = (from, to) => {
     const result = applyMove({ points, dice }, currentPlayer, from, to);
-    if (!result.points) return;
+    if (!result) return;
     setPoints(result.points);
     setDice(result.dice);
     if (result.dice.length === 0) endTurn();
@@ -57,7 +57,7 @@ const Board = () => {
         const dest = from + die * direction;
         if (dest >= 0 && dest <= 23) {
           const t = points[dest];
-          if (!t || !t.color || t.color === color || t.count === 1) {
+          if (!t.color || t.color === color || t.count === 1) {
             targets.add(dest);
           }
         }
@@ -70,7 +70,6 @@ const Board = () => {
   const handlePointClick = (index) => {
     if (autoPlay || stepPlay || currentPlayer !== '0') return;
     const point = points[index];
-    if (!point) return;
     if (selected === null) {
       if (point.color === 'white' && point.count > 0) {
         setSelected(index);

--- a/components/Dice.js
+++ b/components/Dice.js
@@ -1,8 +1,7 @@
 import React from 'https://esm.sh/react@18.3.1';
 
-const Dice = ({ values }) => {
-  if (!Array.isArray(values)) return null;
-  return React.createElement(
+const Dice = ({ values }) =>
+  React.createElement(
     'div',
     { className: 'flex space-x-2 justify-center mt-2' },
     values.map((value, i) =>
@@ -18,6 +17,5 @@ const Dice = ({ values }) => {
       )
     )
   );
-};
 
 export default Dice;

--- a/game.js
+++ b/game.js
@@ -31,11 +31,12 @@ const createInitialPoints = () => {
 export const moveChecker = (state, player, from, to) => {
   const color = player === '0' ? 'white' : 'black';
   const distance = Math.abs(to - from);
-  if (!Array.isArray(state.dice) || !state.dice.includes(distance)) return state;
+  if (!state.dice.includes(distance)) return null;
+
   const source = state.points[from];
   const target = state.points[to];
-  if (source.color !== color || source.count === 0) return state;
-  if (target.color && target.color !== color && target.count > 1) return state;
+  if (source.color !== color || source.count === 0) return null;
+  if (target.color && target.color !== color && target.count > 1) return null;
 
   const points = state.points.map((p) => ({ ...p }));
   const src = points[from];
@@ -44,23 +45,22 @@ export const moveChecker = (state, player, from, to) => {
   src.count--;
   if (src.count === 0) src.color = null;
 
-  if (tgt.color && tgt.color !== color && tgt.count === 1) {
+  if (tgt.color && tgt.color !== color) {
     tgt.color = color;
     tgt.count = 1;
   } else {
-    if (!tgt.color) tgt.color = color;
-    tgt.count++;
+    tgt.color = color;
+    tgt.count += 1;
   }
 
   const dice = [...state.dice];
   const dieIndex = dice.indexOf(distance);
-  if (dieIndex >= 0) dice.splice(dieIndex, 1);
+  dice.splice(dieIndex, 1);
 
   return { points, dice };
 };
 
 const getWinner = (points) => {
-  if (!Array.isArray(points)) return null;
   const whiteTotal = points
     .filter((p) => p.color === 'white')
     .reduce((sum, p) => sum + p.count, 0);


### PR DESCRIPTION
## Summary
- streamline dice rendering by trusting our data structure
- simplify moveChecker and winner detection to rely on internal state
- remove redundant board checks after adopting our own point structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f2db8408832d9639118e6664f992