### PR TITLE
Fix checker orientation and initial board layout

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -324,18 +324,20 @@ const Board = () => {
     React.createElement(
       'div',
       { className: 'grid grid-cols-12 gap-1' },
-      ...points.slice(0, 12).map((p, i) =>
-        React.createElement(Point, {
-          key: i,
+      ...points.slice(0, 12).map((_, i) => {
+        const idx = 11 - i;
+        const p = points[idx];
+        return React.createElement(Point, {
+          key: idx,
           point: p,
-          index: i,
-          selected: selected === i,
-          highlighted: possibleMoves.includes(i),
-          movedFrom: lastMove && lastMove.from === i,
-          movedTo: lastMove && lastMove.to === i,
-          onClick: () => handlePointClick(i),
-        })
-      )
+          index: idx,
+          selected: selected === idx,
+          highlighted: possibleMoves.includes(idx),
+          movedFrom: lastMove && lastMove.from === idx,
+          movedTo: lastMove && lastMove.to === idx,
+          onClick: () => handlePointClick(idx),
+        });
+      })
     ),
     React.createElement(
       'div',

--- a/components/Point.js
+++ b/components/Point.js
@@ -17,7 +17,7 @@ const Point = ({
     : isTop
       ? 'border-b-orange-700'
       : 'border-t-orange-700';
-  const number = index < 12 ? index + 13 : 24 - index;
+  const number = 24 - index;
 
   const checkers = [];
   for (let i = 0; i < point.count; i++) {

--- a/game.js
+++ b/game.js
@@ -14,16 +14,16 @@ const createInitialPoints = () => {
     .map(() => ({ color: null, count: 0 }));
 
   // White checkers
-  pts[0] = { color: 'white', count: 5 }; // point 13
-  pts[11] = { color: 'white', count: 2 }; // point 24
+  pts[0] = { color: 'white', count: 2 }; // point 24
+  pts[11] = { color: 'white', count: 5 }; // point 13
   pts[16] = { color: 'white', count: 3 }; // point 8
   pts[18] = { color: 'white', count: 5 }; // point 6
 
   // Black checkers
   pts[23] = { color: 'black', count: 2 }; // point 1
   pts[12] = { color: 'black', count: 5 }; // point 12
-  pts[4] = { color: 'black', count: 3 }; // point 17
-  pts[6] = { color: 'black', count: 5 }; // point 19
+  pts[7] = { color: 'black', count: 3 }; // point 17
+  pts[5] = { color: 'black', count: 5 }; // point 19
 
   return pts;
 };


### PR DESCRIPTION
## Summary
- Correct initial checker placement to standard points
- Display board points with correct numbering and orientation
- Show top row in reverse index order so movement follows board layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/SingleBackgammon/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa00939690832da2bd076f05f7fe04