### PR TITLE
Add bearing off mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Single Backgammon is a single-player backgammon implementation built with plain 
 
 ## How to play
 
-Roll the dice with the **Roll** button or press **Enter**. Selecting a checker highlights its legal destinations; click a highlighted point to move. Use the **Help** button at any time to read instructions.
+Roll the dice with the **Roll** button or press **Enter**. Selecting a checker highlights its legal destinations; click a highlighted point to move. Once all your checkers are in your home board, double-click a checker to bear it off. Use the **Help** button at any time to read instructions.
 
 ## Features so far
 
@@ -14,6 +14,7 @@ Roll the dice with the **Roll** button or press **Enter**. Selecting a checker h
 - Startup instructions overlay and an in-game help dialog explain the rules.
 - A cache-clearing reload button is available for development or troubleshooting.
 - A log button captures the current game state to the console for debugging.
+- Checkers can be borne off from the home board by double-clicking.
 
 ## Development
 

--- a/components/Board.js
+++ b/components/Board.js
@@ -6,6 +6,7 @@ import {
   createInitialPoints,
   moveChecker as applyMove,
   getWinner,
+  allInHome,
 } from '../game.js';
 
 const Board = () => {
@@ -55,12 +56,23 @@ const Board = () => {
       const color = currentPlayer === '0' ? 'white' : 'black';
       const direction = currentPlayer === '0' ? 1 : -1;
       const targets = new Set();
+      const inHome = allInHome(points, color);
       dice.forEach((die) => {
         const dest = from + die * direction;
         if (dest >= 0 && dest <= 23) {
           const t = points[dest];
           if (!t.color || t.color === color || t.count === 1) {
             targets.add(dest);
+          }
+        } else if (inHome) {
+          if (color === 'white') {
+            const noBehind = points.slice(0, from).every((p) => p.color !== 'white');
+            if (dest > 23 && noBehind) targets.add(dest);
+          } else {
+            const noBehind = points
+              .slice(from + 1)
+              .every((p) => p.color !== 'black');
+            if (dest < 0 && noBehind) targets.add(dest);
           }
         }
       });
@@ -81,6 +93,14 @@ const Board = () => {
       moveChecker(selected, index);
       setSelected(null);
       setPossibleMoves([]);
+    } else if (
+      index === selected &&
+      possibleMoves.some((m) => m < 0 || m > 23)
+    ) {
+      const off = possibleMoves.find((m) => m < 0 || m > 23);
+      moveChecker(selected, off);
+      setSelected(null);
+      setPossibleMoves([]);
     } else if (point.color === 'white' && point.count > 0) {
       setSelected(index);
       setPossibleMoves(calculateMoves(index));
@@ -94,6 +114,7 @@ const Board = () => {
     const color = currentPlayer === '0' ? 'white' : 'black';
     const direction = currentPlayer === '0' ? 1 : -1;
     const possible = [];
+    const inHome = allInHome(points, color);
 
     for (let i = 0; i < 24; i++) {
       const p = points[i];
@@ -104,6 +125,18 @@ const Board = () => {
             const t = points[dest];
             if (!t.color || t.color === color || t.count === 1) {
               possible.push([i, dest]);
+            }
+          } else if (inHome) {
+            if (color === 'white') {
+              const noBehind = points
+                .slice(0, i)
+                .every((pnt) => pnt.color !== 'white');
+              if (dest > 23 && noBehind) possible.push([i, dest]);
+            } else {
+              const noBehind = points
+                .slice(i + 1)
+                .every((pnt) => pnt.color !== 'black');
+              if (dest < 0 && noBehind) possible.push([i, dest]);
             }
           }
         });
@@ -187,7 +220,7 @@ const Board = () => {
             React.createElement(
               'li',
               null,
-              'Once all your checkers are in your home board you can bear them off.'
+              'Once all your checkers are in your home board you can bear them off by double-clicking a checker.'
             )
           ),
           React.createElement(


### PR DESCRIPTION
## Summary
- allow checkers to be borne off once all of a player's pieces reach the home board
- support double-click bearing off in the UI and AI moves
- document bearing off in help text and README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa18e950e0832da97bd6731423057d