### PR TITLE
Display borne-off checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Roll the dice with the **Roll** button or press **Enter**. Selecting a checker h
 - A cache-clearing reload button is available for development or troubleshooting.
 - A log button captures the current game state to the console for debugging.
 - Checkers can be borne off from the home board by double-clicking.
+- Borne-off checkers are displayed next to the board.
 
 ## Development
 

--- a/components/Board.js
+++ b/components/Board.js
@@ -23,6 +23,14 @@ const Board = () => {
   const [lastMove, setLastMove] = React.useState(null);
   const [scores, setScores] = React.useState({ white: 0, black: 0 });
 
+  const offCounts = React.useMemo(() => {
+    const counts = { white: 15, black: 15 };
+    points.forEach((p) => {
+      if (p.color) counts[p.color] -= p.count;
+    });
+    return counts;
+  }, [points]);
+
   const endTurn = () => {
     setCurrentPlayer((p) => (p === '0' ? '1' : '0'));
     setTurn((t) => t + 1);
@@ -296,6 +304,42 @@ const Board = () => {
       'div',
       { className: 'mb-4' },
       `Score - White: ${scores.white} | Black: ${scores.black}`
+    ),
+    React.createElement(
+      'div',
+      { className: 'mb-4 flex justify-between' },
+      React.createElement(
+        'div',
+        { className: 'flex items-center' },
+        React.createElement('span', { className: 'mr-2' }, 'White off:'),
+        React.createElement(
+          'div',
+          { className: 'flex space-x-1' },
+          ...Array.from({ length: offCounts.white }).map((_, i) =>
+            React.createElement('div', {
+              key: i,
+              className:
+                'w-4 h-4 rounded-full border border-gray-800 bg-white',
+            })
+          )
+        )
+      ),
+      React.createElement(
+        'div',
+        { className: 'flex items-center' },
+        React.createElement('span', { className: 'mr-2' }, 'Black off:'),
+        React.createElement(
+          'div',
+          { className: 'flex space-x-1' },
+          ...Array.from({ length: offCounts.black }).map((_, i) =>
+            React.createElement('div', {
+              key: i,
+              className:
+                'w-4 h-4 rounded-full border border-gray-800 bg-black',
+            })
+          )
+        )
+      )
     ),
     React.createElement(
       'div',


### PR DESCRIPTION
## Summary
- Show how many checkers each player has borne off
- Document borne-off checker display in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa21e9bd3c832da5cc62105c55c965