### PR TITLE
Add bar logic and highlight home board

### DIFF
--- a/components/Point.js
+++ b/components/Point.js
@@ -18,6 +18,13 @@ const Point = ({
       ? 'border-b-orange-700'
       : 'border-t-orange-700';
   const number = 24 - index;
+  const isWhiteHome = index >= 18;
+  const isBlackHome = index <= 5;
+  const homeClass = isWhiteHome
+    ? 'bg-green-100'
+    : isBlackHome
+    ? 'bg-red-100'
+    : '';
 
   const checkers = [];
   for (let i = 0; i < point.count; i++) {
@@ -37,10 +44,10 @@ const Point = ({
       'data-point': index,
       onClick,
       className: `relative w-8 h-32 flex justify-center items-center cursor-pointer ${
-        selected ? 'bg-green-200' : ''
-      } ${highlighted ? 'bg-blue-200' : ''} ${movedFrom ? 'bg-red-200' : ''} ${
-        movedTo ? 'bg-yellow-200' : ''
-      }`,
+        homeClass
+      } ${selected ? 'bg-green-200' : ''} ${highlighted ? 'bg-blue-200' : ''} ${
+        movedFrom ? 'bg-red-200' : ''
+      } ${movedTo ? 'bg-yellow-200' : ''}`,
     },
     React.createElement('div', {
       className: `absolute w-0 h-0 border-l-[16px] border-r-[16px] ${

--- a/game.js
+++ b/game.js
@@ -28,7 +28,8 @@ const createInitialPoints = () => {
   return pts;
 };
 
-const allInHome = (points, color) => {
+const allInHome = (points, color, bar = { white: 0, black: 0 }) => {
+  if (bar[color] > 0) return false;
   if (color === 'white') {
     for (let i = 0; i < 18; i++) {
       if (points[i].color === 'white') return false;
@@ -44,17 +45,29 @@ const allInHome = (points, color) => {
 export const moveChecker = (state, player, from, to) => {
   const color = player === '0' ? 'white' : 'black';
   const direction = color === 'white' ? 1 : -1;
-  const distance = (to - from) * direction;
+  let distance;
+  if (from === -1) {
+    distance = to + 1;
+  } else if (from === 24) {
+    distance = 24 - to;
+  } else {
+    distance = (to - from) * direction;
+  }
   if (distance <= 0 || !state.dice.includes(distance)) return null;
 
-  const source = state.points[from];
-  if (source.color !== color || source.count === 0) return null;
-
   const points = state.points.map((p) => ({ ...p }));
-  const src = points[from];
+  const bar = { ...state.bar };
+
+  if (from === -1 || from === 24) {
+    if (bar[color] === 0) return null;
+  } else {
+    const source = state.points[from];
+    if (source.color !== color || source.count === 0) return null;
+  }
 
   if (to < 0 || to > 23) {
-    if (!allInHome(state.points, color)) return null;
+    if (!allInHome(state.points, color, state.bar)) return null;
+    if (from === -1 || from === 24) return null;
     if (color === 'white') {
       for (let i = 0; i < from; i++) {
         if (state.points[i].color === 'white') return null;
@@ -65,6 +78,7 @@ export const moveChecker = (state, player, from, to) => {
       }
     }
 
+    const src = points[from];
     src.count--;
     if (src.count === 0) src.color = null;
 
@@ -72,18 +86,23 @@ export const moveChecker = (state, player, from, to) => {
     const dieIndex = dice.indexOf(distance);
     dice.splice(dieIndex, 1);
 
-    return { points, dice };
+    return { points, dice, bar };
   }
 
   const target = state.points[to];
   if (target.color && target.color !== color && target.count > 1) return null;
 
+  if (from !== -1 && from !== 24) {
+    const src = points[from];
+    src.count--;
+    if (src.count === 0) src.color = null;
+  } else {
+    bar[color]--;
+  }
+
   const tgt = points[to];
-
-  src.count--;
-  if (src.count === 0) src.color = null;
-
   if (tgt.color && tgt.color !== color) {
+    bar[tgt.color]++;
     tgt.color = color;
     tgt.count = 1;
   } else {
@@ -95,16 +114,16 @@ export const moveChecker = (state, player, from, to) => {
   const dieIndex = dice.indexOf(distance);
   dice.splice(dieIndex, 1);
 
-  return { points, dice };
+  return { points, dice, bar };
 };
 
-const getWinner = (points) => {
-  const whiteTotal = points
-    .filter((p) => p.color === 'white')
-    .reduce((sum, p) => sum + p.count, 0);
-  const blackTotal = points
-    .filter((p) => p.color === 'black')
-    .reduce((sum, p) => sum + p.count, 0);
+const getWinner = (points, bar = { white: 0, black: 0 }) => {
+  const whiteTotal =
+    points.filter((p) => p.color === 'white').reduce((sum, p) => sum + p.count, 0) +
+    bar.white;
+  const blackTotal =
+    points.filter((p) => p.color === 'black').reduce((sum, p) => sum + p.count, 0) +
+    bar.black;
   if (whiteTotal === 0) return '0';
   if (blackTotal === 0) return '1';
   return null;


### PR DESCRIPTION
## Summary
- Track checkers on the bar and require re-entry before bearing off
- Display bar counts, restrict moves while on the bar, and tint home zones
- Update move logic and winner detection to include bar pieces

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9371ee04832da16f2e73c4560bf4