### PR TITLE
Add manual roll step after AI turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Roll the dice with the **Roll** button or press **Enter**. Selecting a checker h
 
 ## Features so far
 
-- Visual dice with clear face values that roll automatically at game start and at the beginning of each turn.
+- Visual dice with clear face values that roll automatically at game start and for the computer, and by clicking **Roll** to begin the player's turn.
 - Checkers highlight their available moves and can be dragged to legal points.
 - Autoplay mode lets the AI play itself, with a step-through option for pausing and advancing one move at a time.
 - Startup instructions overlay and an in-game help dialog explain the rules.


### PR DESCRIPTION
## Summary
- keep AI's dice on screen until the player rolls
- auto-roll for AI and autoplay modes
- document new Roll button and updated turn flow

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa93b8eafc832db5f8a870b52b512f