### PR TITLE
Add visual bar for captured checkers

### DIFF
--- a/components/Bar.js
+++ b/components/Bar.js
@@ -1,0 +1,25 @@
+import React from 'https://esm.sh/react@18.3.1';
+
+const Bar = ({ color, count, onClick }) => {
+  const checkers = [];
+  for (let i = 0; i < count; i++) {
+    checkers.push(
+      React.createElement('div', {
+        key: i,
+        className: `w-6 h-6 rounded-full border border-gray-800 mb-1 ${
+          color === 'white' ? 'bg-white' : 'bg-black'
+        }`,
+      })
+    );
+  }
+  return React.createElement(
+    'div',
+    {
+      onClick,
+      className: 'w-8 h-32 flex flex-col items-center justify-center bg-gray-200',
+    },
+    ...checkers
+  );
+};
+
+export default Bar;

--- a/components/Board.js
+++ b/components/Board.js
@@ -1,6 +1,7 @@
 import React from 'https://esm.sh/react@18.3.1';
 import Point from './Point.js';
 import Dice from './Dice.js';
+import Bar from './Bar.js';
 import {
   rollDice,
   createInitialPoints,
@@ -318,6 +319,11 @@ const Board = () => {
             React.createElement(
               'li',
               null,
+              'Checkers on the bar must re-enter before you can move others.'
+            ),
+            React.createElement(
+              'li',
+              null,
               'Once all your checkers are in your home board you can bear them off by double-clicking a checker.'
             )
           ),
@@ -377,8 +383,19 @@ const Board = () => {
     ),
     React.createElement(
       'div',
-      { className: 'mb-2' },
-      `Bar - White: ${bar.white} | Black: ${bar.black}`
+      { className: 'mb-2 flex justify-center space-x-8' },
+      React.createElement(
+        'div',
+        { className: 'flex flex-col items-center' },
+        React.createElement('span', null, `White bar (${bar.white})`),
+        React.createElement(Bar, { color: 'white', count: bar.white })
+      ),
+      React.createElement(
+        'div',
+        { className: 'flex flex-col items-center' },
+        React.createElement('span', null, `Black bar (${bar.black})`),
+        React.createElement(Bar, { color: 'black', count: bar.black })
+      )
     ),
     React.createElement(
       'div',


### PR DESCRIPTION
## Summary
- Implement Bar component to display captured pieces for each player
- Integrate bar display into board and update in-game instructions about re-entering checkers from the bar

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68aa93eaf680832db366083f012ba81c