### PR TITLE
Enforce landscape orientation on iPhone

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,28 @@ root.render(
   )
 );
 
+function enforceLandscape() {
+  if (!/iPhone/i.test(window.navigator.userAgent)) {
+    return;
+  }
+
+  const warning = document.getElementById('orientation-warning');
+  const rootEl = document.getElementById('root');
+  const isPortrait = window.matchMedia('(orientation: portrait)').matches;
+
+  if (isPortrait) {
+    warning.classList.remove('hidden');
+    rootEl.classList.add('hidden');
+  } else {
+    warning.classList.add('hidden');
+    rootEl.classList.remove('hidden');
+  }
+}
+
+window.addEventListener('load', enforceLandscape);
+window.addEventListener('resize', enforceLandscape);
+window.addEventListener('orientationchange', enforceLandscape);
+
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('./service-worker.js');

--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
   <script src="./console-capture.js"></script>
 </head>
 <body class="flex items-center justify-center min-h-screen bg-gray-100">
+  <div id="orientation-warning" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-gray-900 text-white text-xl">
+    Please rotate your device to landscape
+  </div>
   <div id="root"></div>
   <script type="module" src="./app.js"></script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "start_url": "./index.html",
   "scope": "./",
   "display": "standalone",
+  "orientation": "landscape",
   "background_color": "#ffffff",
   "theme_color": "#000000",
   "icons": [


### PR DESCRIPTION
## Summary
- Add landscape orientation overlay and iPhone-only enforcement script
- Restrict PWA manifest to landscape orientation

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aab7cd40e8832d989e9aab55fbc263