### PR TITLE
Use gray backgrounds for home boards

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -549,7 +549,7 @@ const Board = () => {
         'div',
         { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
         React.createElement('div', { className: 'col-span-6' }),
-        React.createElement('div', { className: 'col-span-6 bg-black' })
+        React.createElement('div', { className: 'col-span-6 bg-gray-700' })
       ),
       React.createElement(
         'div',
@@ -577,7 +577,7 @@ const Board = () => {
         'div',
         { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
         React.createElement('div', { className: 'col-span-6' }),
-        React.createElement('div', { className: 'col-span-6 bg-white' })
+        React.createElement('div', { className: 'col-span-6 bg-gray-300' })
       ),
       React.createElement(
         'div',


### PR DESCRIPTION
## Summary
- Tinted black home area with dark gray for clearer checker contrast
- Shaded white home area with light gray to improve visibility

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabe0dee24832d975f7d153cb6c95f