### PR TITLE
Fix unmatched parentheses in Board component

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -626,7 +626,8 @@ const Board = () => {
       chatPlaceholder,
       videoPlaceholder
     )
-  );
+  )
+);
 };
 
 export default Board;


### PR DESCRIPTION
## Summary
- close an extra React.createElement wrapper to resolve syntax error in Board.js

## Testing
- `node --experimental-network-imports components/Board.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68aac2d576a8832d90c93452f090219a