### PR TITLE
Display chat and video on small screens

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -299,7 +299,7 @@ const Board = () => {
     { className: 'flex justify-center' },
     React.createElement(
       'div',
-      { className: 'w-full max-w-[428px] text-center' },
+      { className: 'w-full max-w-[428px] text-center flex-shrink-0' },
       showInstructions &&
         React.createElement(
           'div',
@@ -621,7 +621,7 @@ const Board = () => {
       'div',
       {
         className:
-          'hidden md:ml-4 md:w-64 md:flex md:flex-col md:space-y-4',
+          'ml-2 w-32 flex flex-col space-y-2 md:ml-4 md:w-64 md:space-y-4 flex-shrink-0',
       },
       chatPlaceholder,
       videoPlaceholder


### PR DESCRIPTION
## Summary
- Remove responsive hiding so chat and video placeholders are always visible
- Add responsive sizing to side column and prevent board from shrinking

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aacf3e9fe0832db7f14887528ae9d1