### PR TITLE
Add title bar and relocate bar and scores

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -399,23 +399,18 @@ const Board = () => {
       ),
     React.createElement(
       'div',
-      { className: 'mb-4' },
-      `Score - White: ${scores.white} | Black: ${scores.black}`
-    ),
-    React.createElement(
-      'div',
-      { className: 'mb-2 flex justify-center space-x-8' },
+      { className: 'mb-4 bg-green-500 text-white' },
       React.createElement(
         'div',
-        { className: 'flex flex-col items-center' },
-        React.createElement('span', null, `White bar (${bar.white})`),
-        React.createElement(Bar, { color: 'white', count: bar.white })
+        { className: 'text-center font-bold' },
+        'SingleBackgammon'
       ),
       React.createElement(
         'div',
-        { className: 'flex flex-col items-center' },
-        React.createElement('span', null, `Black bar (${bar.black})`),
-        React.createElement(Bar, { color: 'black', count: bar.black })
+        { className: 'flex items-center justify-between px-4 py-1' },
+        React.createElement('span', { className: 'font-bold' }, scores.white),
+        React.createElement(Dice, { values: displayDice }),
+        React.createElement('span', { className: 'font-bold text-black' }, scores.black)
       )
     ),
     React.createElement(
@@ -465,7 +460,6 @@ const Board = () => {
       React.createElement(
         'div',
         { className: 'flex items-center space-x-2 mt-2' },
-        React.createElement(Dice, { values: displayDice }),
         stepPlay &&
           !waitingForRoll &&
           React.createElement(
@@ -590,6 +584,12 @@ const Board = () => {
           });
         })
       )
+    ),
+    React.createElement(
+      'div',
+      { className: 'flex justify-center mb-4 space-x-4' },
+      React.createElement(Bar, { color: 'white', count: bar.white }),
+      React.createElement(Bar, { color: 'black', count: bar.black })
     ),
     React.createElement(
       'div',

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#008000" />
   <title>SingleBackgammon</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="manifest" href="./manifest.json" />

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "display": "standalone",
   "orientation": "landscape",
   "background_color": "#ffffff",
-  "theme_color": "#000000",
+  "theme_color": "#008000",
   "icons": [
     {
       "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 192 192'><rect width='192' height='192' fill='%23000'/></svg>",


### PR DESCRIPTION
## Summary
- Add green title bar with dice in center and color-coded scores on sides
- Move bar checkers between board halves
- Update theme color to green for PWA header

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad08a0bc0832d9ba4e2e46850fb59