### PR TITLE
Fix chat and video visibility on right side

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -299,7 +299,7 @@ const Board = () => {
     { className: 'flex justify-center' },
     React.createElement(
       'div',
-      { className: 'w-full max-w-[428px] text-center flex-shrink-0' },
+      { className: 'w-[428px] text-center flex-shrink-0' },
       showInstructions &&
         React.createElement(
           'div',


### PR DESCRIPTION
## Summary
- Fix board layout by giving the board a fixed width so chat and video placeholders display on the right side

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aad2e47d00832db1ba5992d96af5c7