### PR TITLE
Make PWA full screen

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -296,10 +296,10 @@ const Board = () => {
 
   return React.createElement(
     'div',
-    { className: 'flex justify-center' },
+    { className: 'w-full' },
     React.createElement(
       'div',
-      { className: 'w-full max-w-[428px] text-center flex-shrink-0' },
+      { className: 'w-full text-center flex-shrink-0' },
       showInstructions &&
         React.createElement(
           'div',
@@ -399,7 +399,7 @@ const Board = () => {
       ),
     React.createElement(
       'div',
-      { className: 'mb-4 bg-green-500 text-white' },
+      { className: 'mb-4 bg-green-500 text-white w-full' },
       React.createElement(
         'div',
         { className: 'text-center font-bold' },
@@ -407,7 +407,7 @@ const Board = () => {
       ),
       React.createElement(
         'div',
-        { className: 'flex items-center justify-between px-4 py-1' },
+        { className: 'flex items-center justify-between px-4 py-1 w-full' },
         React.createElement('span', { className: 'font-bold' }, scores.white),
         React.createElement(Dice, { values: displayDice }),
         React.createElement('span', { className: 'font-bold text-black' }, scores.black)

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <link rel="manifest" href="./manifest.json" />
   <script src="./console-capture.js"></script>
 </head>
-<body class="flex items-center justify-center min-h-screen bg-gray-100">
+  <body class="min-h-screen w-full bg-gray-100">
   <div id="orientation-warning" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-gray-900 text-white text-xl">
     Please rotate your device to landscape
   </div>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "SingleBackgammon",
   "start_url": "./index.html",
   "scope": "./",
-  "display": "standalone",
+  "display": "fullscreen",
   "orientation": "landscape",
   "background_color": "#ffffff",
   "theme_color": "#008000",


### PR DESCRIPTION
## Summary
- Allow page body to expand to full viewport width
- Switch PWA manifest to fullscreen display mode
- Stretch game title bar across the screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aadcb8dfb0832da3d9b801e7968bca