### PR TITLE
Enable full screen PWA and stretch title bar

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -300,15 +300,12 @@ const Board = () => {
 
   return React.createElement(
     'div',
-    { className: 'flex justify-center' },
-    React.createElement(
-      'div',
-      { className: 'w-[428px] text-center flex-shrink-0' },
-      showInstructions &&
-        React.createElement(
-          'div',
-          {
-            className:
+    { className: 'flex flex-col items-center w-full' },
+    showInstructions &&
+      React.createElement(
+        'div',
+        {
+          className:
             'fixed inset-0 z-10 flex items-center justify-center bg-black bg-opacity-50',
         },
         React.createElement(
@@ -357,35 +354,35 @@ const Board = () => {
             { className: 'mb-2 text-sm' },
             'Buttons above the board provide extra options:'
           ),
+          React.createElement(
+            'ul',
+            { className: 'mb-4 list-disc pl-5 text-sm space-y-1' },
             React.createElement(
-              'ul',
-              { className: 'mb-4 list-disc pl-5 text-sm space-y-1' },
-              React.createElement(
-                'li',
-                null,
-                'End Turn: roll the dice and pass play to the computer opponent.'
-              ),
-              React.createElement(
-                'li',
-                null,
-                'Step: watch the computer play one move at a time. Press Next for each move.'
-              ),
-              React.createElement(
-                'li',
-                null,
-                'Autoplay: let the computer control both sides automatically.'
-              ),
-              React.createElement(
-                'li',
-                null,
-                'New Game: reset the board and keep the running score.'
-              ),
-              React.createElement(
-                'li',
-                null,
-                'Reload Game: clear cached data and restart the match.'
-              )
+              'li',
+              null,
+              'End Turn: roll the dice and pass play to the computer opponent.'
             ),
+            React.createElement(
+              'li',
+              null,
+              'Step: watch the computer play one move at a time. Press Next for each move.'
+            ),
+            React.createElement(
+              'li',
+              null,
+              'Autoplay: let the computer control both sides automatically.'
+            ),
+            React.createElement(
+              'li',
+              null,
+              'New Game: reset the board and keep the running score.'
+            ),
+            React.createElement(
+              'li',
+              null,
+              'Reload Game: clear cached data and restart the match.'
+            )
+          ),
           React.createElement(
             'p',
             { className: 'mb-4 text-sm' },
@@ -403,7 +400,7 @@ const Board = () => {
       ),
     React.createElement(
       'div',
-      { className: 'mb-4 bg-green-500 text-white' },
+      { className: 'mb-4 bg-green-500 text-white w-full' },
       React.createElement(
         'div',
         { className: 'text-center font-bold' },
@@ -411,7 +408,10 @@ const Board = () => {
       ),
       React.createElement(
         'div',
-        { className: 'flex items-center justify-between px-4 py-1' },
+        {
+          className:
+            'flex items-center justify-between px-4 py-1 max-w-[428px] mx-auto',
+        },
         React.createElement(
           'div',
           { className: 'flex flex-col items-center' },
@@ -443,8 +443,11 @@ const Board = () => {
     ),
     React.createElement(
       'div',
-      { className: 'mb-4 flex justify-between' },
+      { className: 'w-[428px] text-center flex-shrink-0' },
       React.createElement(
+        'div',
+        { className: 'mb-4 flex justify-between' },
+        React.createElement(
         'div',
         { className: 'flex items-center' },
         React.createElement('span', { className: 'mr-2' }, 'White off:'),

--- a/index.html
+++ b/index.html
@@ -4,16 +4,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#008000" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
   <title>SingleBackgammon</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="manifest" href="./manifest.json" />
   <script src="./console-capture.js"></script>
 </head>
-<body class="flex items-center justify-center min-h-screen bg-gray-100">
+<body class="min-h-screen bg-gray-100">
   <div id="orientation-warning" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-gray-900 text-white text-xl">
     Please rotate your device to landscape
   </div>
-  <div id="root"></div>
+  <div id="root" class="w-full"></div>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "SingleBackgammon",
   "start_url": "./index.html",
   "scope": "./",
-  "display": "standalone",
+  "display": "fullscreen",
   "orientation": "landscape",
   "background_color": "#ffffff",
   "theme_color": "#008000",


### PR DESCRIPTION
## Summary
- Set the web app manifest to `fullscreen` display for a true PWA experience
- Add Apple mobile meta and remove centering so the title bar spans the entire screen
- Restructure the board layout so header uses full width while game board stays centered

## Testing
- `node --check components/Board.js`
- `node --check app.js`
- `jq . manifest.json`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aadd7c2214832d9be4c274452075ce