### PR TITLE
feat: set board background green

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -595,7 +595,7 @@ const Board = () => {
         'div',
         { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
         React.createElement('div', { className: 'col-span-6' }),
-        React.createElement('div', { className: 'col-span-6 bg-gray-700' })
+        React.createElement('div', { className: 'col-span-6 bg-green-700' })
       ),
       React.createElement(
         'div',
@@ -629,7 +629,7 @@ const Board = () => {
         'div',
         { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
         React.createElement('div', { className: 'col-span-6' }),
-        React.createElement('div', { className: 'col-span-6 bg-gray-300' })
+        React.createElement('div', { className: 'col-span-6 bg-green-300' })
       ),
       React.createElement(
         'div',


### PR DESCRIPTION
## Summary
- replace gray board halves with green tones for a classic look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae0315920832d9395c1ea7b28968a