### PR TITLE
feat: make board background green

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -593,11 +593,11 @@ const Board = () => {
     ),
     React.createElement(
       'div',
-      { className: 'relative' },
+      { className: 'relative bg-green-600' },
       React.createElement(
         'div',
         { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
-        React.createElement('div', { className: 'col-span-6' }),
+        React.createElement('div', { className: 'col-span-6 bg-green-600' }),
         React.createElement('div', { className: 'col-span-6 bg-gray-700' })
       ),
       React.createElement(
@@ -627,11 +627,11 @@ const Board = () => {
     ),
       React.createElement(
         'div',
-        { className: 'relative' },
+        { className: 'relative bg-green-600' },
         React.createElement(
           'div',
           { className: 'absolute inset-0 grid grid-cols-12 -z-10' },
-          React.createElement('div', { className: 'col-span-6' }),
+          React.createElement('div', { className: 'col-span-6 bg-green-600' }),
           React.createElement('div', { className: 'col-span-6 bg-gray-300' })
         ),
         React.createElement(


### PR DESCRIPTION
## Summary
- paint the board's default background green
- retain gray highlights for both players' home areas

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae1e102a8832da106053df7d1a8bf