### PR TITLE
Reduce out-tile bar and checkers size

### DIFF
--- a/components/Bar.js
+++ b/components/Bar.js
@@ -6,7 +6,7 @@ const Bar = ({ color, count, onClick }) => {
     checkers.push(
       React.createElement('div', {
         key: i,
-        className: `w-6 h-6 rounded-full border border-gray-800 mr-1 last:mr-0 ${
+        className: `w-3 h-3 rounded-full border border-gray-800 mr-0.5 last:mr-0 ${
           color === 'white' ? 'bg-white' : 'bg-black'
         }`,
       })
@@ -17,7 +17,7 @@ const Bar = ({ color, count, onClick }) => {
     {
       onClick,
       className:
-        'w-32 h-8 flex flex-row items-center justify-center bg-gray-200',
+        'w-16 h-4 flex flex-row items-center justify-center bg-gray-200',
     },
     ...checkers
   );

--- a/components/Board.js
+++ b/components/Board.js
@@ -456,12 +456,12 @@ const Board = () => {
         React.createElement('span', { className: 'mr-2' }, 'White off:'),
         React.createElement(
           'div',
-          { className: 'flex space-x-1' },
+          { className: 'flex space-x-0.5' },
           ...Array.from({ length: offCounts.white }).map((_, i) =>
             React.createElement('div', {
               key: i,
               className:
-                'w-4 h-4 rounded-full border border-gray-800 bg-white',
+                'w-2 h-2 rounded-full border border-gray-800 bg-white',
             })
           )
         )
@@ -472,12 +472,12 @@ const Board = () => {
         React.createElement('span', { className: 'mr-2' }, 'Black off:'),
         React.createElement(
           'div',
-          { className: 'flex space-x-1' },
+          { className: 'flex space-x-0.5' },
           ...Array.from({ length: offCounts.black }).map((_, i) =>
             React.createElement('div', {
               key: i,
               className:
-                'w-4 h-4 rounded-full border border-gray-800 bg-black',
+                'w-2 h-2 rounded-full border border-gray-800 bg-black',
             })
           )
         )


### PR DESCRIPTION
## Summary
- Shrink bar checkers and container to half size
- Halve size of borne-off tile indicators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae3d810fc832d90d1bd86be403e65