### PR TITLE
Remove chat and video placeholders

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -280,24 +280,6 @@ const Board = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [autoPlay, stepPlay, makeAIMove, endTurn, waitingForRoll, rollForCurrentPlayer]);
 
-  const chatPlaceholder = React.createElement(
-    'div',
-    {
-      className:
-        'flex-1 border-2 border-dashed border-gray-400 flex items-center justify-center',
-    },
-    'Chat'
-  );
-
-  const videoPlaceholder = React.createElement(
-    'div',
-    {
-      className:
-        'flex-1 border-2 border-dashed border-gray-400 flex items-center justify-center',
-    },
-    'Video'
-  );
-
   const controlPanel = React.createElement(
     'div',
     { className: 'w-1/5 p-2 flex flex-col space-y-2' },
@@ -651,12 +633,10 @@ const Board = () => {
         )
       )
     ),
-    React.createElement(
-      'div',
-      { className: 'w-1/5 p-2 flex flex-col space-y-2' },
-      chatPlaceholder,
-      videoPlaceholder
-    )
+    // Keep empty space on the right side for future features
+    React.createElement('div', {
+      className: 'w-1/5 p-2 flex flex-col space-y-2'
+    })
   )
 );
 };


### PR DESCRIPTION
## Summary
- remove chat and video placeholder elements from the board
- keep empty right-hand panel for future features

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aae8162ec8832db68ea0dee5932779