### PR TITLE
Add placeholders for video and chat panel

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -601,10 +601,27 @@ const Board = () => {
       React.createElement(Rack, { color: 'white', count: offCounts.white }),
       React.createElement(Rack, { color: 'black', count: offCounts.black })
     ),
-    // Keep empty space on the right side for future features
-    React.createElement('div', {
-      className: 'w-1/5 p-2 flex flex-col space-y-2'
-    })
+    // Placeholder area on the right for future video and chat features
+    React.createElement(
+      'div',
+      { className: 'w-1/5 p-2 flex flex-col space-y-2 h-full' },
+      React.createElement(
+        'div',
+        {
+          className:
+            'flex-1 bg-gray-300 flex items-center justify-center border border-gray-400',
+        },
+        'Video'
+      ),
+      React.createElement(
+        'div',
+        {
+          className:
+            'flex-1 bg-gray-200 flex items-center justify-center border border-gray-400',
+        },
+        'Chat'
+      )
+    )
   )
 );
 };


### PR DESCRIPTION
## Summary
- Reserve right-side layout space with placeholders for future video and chat features.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaef34fc1c832d923c9e57eb15ea54