### PR TITLE
Add video placeholder and basic chat panel

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -3,6 +3,7 @@ import Point from './Point.js';
 import Dice from './Dice.js';
 import Bar from './Bar.js';
 import Rack from './Rack.js';
+import Chat from './Chat.js';
 import {
   rollDice,
   createInitialPoints,
@@ -601,26 +602,14 @@ const Board = () => {
       React.createElement(Rack, { color: 'white', count: offCounts.white }),
       React.createElement(Rack, { color: 'black', count: offCounts.black })
     ),
-    // Placeholder area on the right for future video and chat features
+    // Right side area for video placeholder and chat
     React.createElement(
       'div',
       { className: 'w-1/5 p-2 flex flex-col space-y-2 h-full' },
-      React.createElement(
-        'div',
-        {
-          className:
-            'flex-1 bg-gray-300 flex items-center justify-center border border-gray-400',
-        },
-        'Video'
-      ),
-      React.createElement(
-        'div',
-        {
-          className:
-            'flex-1 bg-gray-200 flex items-center justify-center border border-gray-400',
-        },
-        'Chat'
-      )
+      React.createElement('div', {
+        className: 'w-full aspect-square bg-black border border-gray-400',
+      }),
+      React.createElement(Chat)
     )
   )
 );

--- a/components/Chat.js
+++ b/components/Chat.js
@@ -1,0 +1,52 @@
+import React from 'https://esm.sh/react@18.3.1';
+
+const Chat = () => {
+  const [messages, setMessages] = React.useState([]);
+  const [input, setInput] = React.useState('');
+
+  const sendMessage = () => {
+    const text = input.trim();
+    if (!text) return;
+    setMessages((msgs) => [...msgs, text]);
+    setInput('');
+  };
+
+  return React.createElement(
+    'div',
+    { className: 'flex-1 border border-gray-400 bg-gray-200 flex flex-col' },
+    React.createElement(
+      'div',
+      { className: 'flex-1 overflow-y-auto p-2 space-y-1' },
+      messages.map((msg, i) =>
+        React.createElement(
+          'div',
+          { key: i, className: 'p-1 bg-white rounded shadow' },
+          msg
+        )
+      )
+    ),
+    React.createElement(
+      'div',
+      { className: 'flex p-2 space-x-2' },
+      React.createElement('input', {
+        className: 'flex-1 border rounded p-1',
+        value: input,
+        onChange: (e) => setInput(e.target.value),
+        onKeyDown: (e) => {
+          if (e.key === 'Enter') sendMessage();
+        },
+        placeholder: 'Type message',
+      }),
+      React.createElement(
+        'button',
+        {
+          className: 'px-2 py-1 bg-blue-500 text-white rounded',
+          onClick: sendMessage,
+        },
+        'Send'
+      )
+    )
+  );
+};
+
+export default Chat;


### PR DESCRIPTION
## Summary
- Add reusable Chat component with message list and input
- Integrate chat panel and black video placeholder into board layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf0517680832d86651273937381da