### PR TITLE
Respect iPhone safe areas in PWA layout

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -389,7 +389,13 @@ const Board = () => {
 
   return React.createElement(
     'div',
-    { className: 'flex w-full h-screen' },
+    {
+      className: 'flex w-full',
+      style: {
+        height:
+          'calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
+      },
+    },
     controlPanel,
     React.createElement(
       'div',

--- a/index.html
+++ b/index.html
@@ -2,9 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#008000" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
+  <style>
+    body {
+      padding: env(safe-area-inset-top) env(safe-area-inset-right)
+        env(safe-area-inset-bottom) env(safe-area-inset-left);
+    }
+  </style>
   <title>SingleBackgammon</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="manifest" href="./manifest.json" />


### PR DESCRIPTION
## Summary
- ensure viewport fits iPhone screen and adds safe-area padding
- size main board with safe-area aware height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aafaebce2c832da912349c6ee1e8a2