### PR TITLE
Allow chat panel to scroll

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -612,7 +612,7 @@ const Board = () => {
   // Right side area for video placeholder and chat
   React.createElement(
     'div',
-    { className: 'w-1/5 p-2 flex flex-col space-y-2 h-full' },
+    { className: 'w-1/5 p-2 flex flex-col space-y-2 h-full min-h-0' },
     React.createElement('div', {
       className: 'w-full aspect-square bg-black border border-gray-400',
     }),

--- a/components/Chat.js
+++ b/components/Chat.js
@@ -20,7 +20,10 @@ const Chat = () => {
 
   return React.createElement(
     'div',
-    { className: 'flex-1 border border-gray-400 bg-gray-200 flex flex-col' },
+    {
+      className:
+        'flex-1 min-h-0 border border-gray-400 bg-gray-200 flex flex-col overflow-hidden',
+    },
     React.createElement(
       'div',
       { className: 'flex-1 overflow-y-auto p-2 space-y-1' },


### PR DESCRIPTION
## Summary
- keep the board visible by letting the chat area scroll within its own panel

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aafe014fc0832d9433314dca5b3cf2