### PR TITLE
Remove redundant title text from header

### DIFF
--- a/components/Board.js
+++ b/components/Board.js
@@ -497,11 +497,6 @@ const Board = () => {
       { className: 'mb-4 bg-green-500 text-white w-full' },
       React.createElement(
         'div',
-        { className: 'text-center font-bold' },
-        'SingleBackgammon'
-      ),
-      React.createElement(
-        'div',
         {
           className:
             'flex items-center justify-between px-4 py-1 max-w-[428px] mx-auto',


### PR DESCRIPTION
## Summary
- Remove the "SingleBackgammon" header title to save vertical space.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab13d66364832d8c98b0c95ff4694d