### PR TITLE
Fix chat message overflow

### DIFF
--- a/components/Chat.js
+++ b/components/Chat.js
@@ -51,7 +51,11 @@ const Chat = () => {
       messages.map((msg, i) =>
         React.createElement(
           'div',
-          { key: i, className: 'p-1 bg-white rounded shadow whitespace-pre-wrap' },
+          {
+            key: i,
+            className:
+              'p-1 bg-white rounded shadow whitespace-pre-wrap break-all',
+          },
           msg
         )
       )


### PR DESCRIPTION
## Summary
- prevent long chat messages from overflowing their container by breaking long words

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ab1f9b889c832d8fb883f008d5c422