### PR TITLE
Fix invisible dice values

### DIFF
--- a/components/Dice.js
+++ b/components/Dice.js
@@ -10,7 +10,7 @@ const Dice = ({ values }) =>
         {
           key: i,
           className:
-            'w-10 h-10 flex items-center justify-center border border-gray-800 rounded bg-white text-2xl font-bold',
+            'w-10 h-10 flex items-center justify-center border border-gray-800 rounded bg-white text-black text-2xl font-bold',
           'aria-label': `Die showing ${value}`,
         },
         value


### PR DESCRIPTION
## Summary
- ensure dice text remains black so values are visible against white background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab27cc65c4832d83c142c3705ab02f