### PR TITLE
fix: prevent board scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
   <link rel="manifest" href="./manifest.json" />
   <script src="./console-capture.js"></script>
 </head>
-<body class="min-h-screen bg-gray-100">
+<body class="min-h-screen bg-gray-100 overflow-hidden overscroll-none">
   <div id="orientation-warning" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-gray-900 text-white text-xl">
     Please rotate your device to landscape
   </div>


### PR DESCRIPTION
## Summary
- prevent page from scrolling when swiping on the board by hiding overflow and disabling overscroll on the body element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b08babc832d8efa2d82e48f0729